### PR TITLE
Add org/llm/traces: durable in-repo agent context

### DIFF
--- a/org/llm/traces/README.md
+++ b/org/llm/traces/README.md
@@ -1,0 +1,72 @@
+# org/llm/traces — agent-authored investigation traces & planning
+
+This directory is durable, in-repo context written **by AI agents, for AI agents**
+(and curious humans). It captures the *history and intent* behind non-obvious work:
+root causes, dead ends, design decisions, and the environment knowledge you need to
+be productive here.
+
+## Why this exists (and why it's committed)
+
+Agents keep per-machine memory under `~/.claude/…/memory/`. That memory does **not**
+travel across computers. This project is worked on from multiple machines, so the
+subset of knowledge worth sharing across all of them lives **here, in the repo**,
+where it travels with `git`. If you're an agent starting cold on this repo, read this
+directory first — it's the fastest path to the context your predecessors paid for.
+
+When you finish a non-trivial investigation, add a trace here. Keep memory for the
+machine-local / user-preference stuff; put transmissible engineering history here.
+
+## Start here (recommended reading order)
+
+1. **`test-harness-and-environment.md`** — how to run tests at all (rakubrew, the
+   broken `checkHighlighting` pipeline, logged-errors-as-failures, checkpoint subset).
+   Read this before running anything.
+2. **`parser-generated-lexer-architecture.md`** — `MAINBraid.java` is *generated*;
+   its grammar source is *external*; how the runtime machine works; how to instrument
+   and debug it; the mirror-fix discipline. **Read before touching `parsing/`.**
+
+## Investigation traces (worked examples)
+
+- **`parser-reduce-metaop-mislexing.md`** — `[and]`/`[[]]` reduce metaops mis-lexed,
+  collapsing highlighting from mid-file to EOF. Two root causes, one principle
+  ("a metaop wraps a *complete* base operator regardless of precedence"). PR #47.
+- **`inspection-private-role-methods.md`** — `MissingRoleMethodInspection` wrongly
+  required private (`!`) role methods; Raku only enforces *public* yada-stubs. Settled
+  by asking rakudo directly. PR #47.
+- **`stub-building-index-queries.md`** — a whole class of latent bug: querying the
+  stub index during stub building (silent in prod, hard failure under test). One path
+  fixed (Option A); a second, more pervasive path documented as known-open. PR #47.
+
+## Kotlin-conversion roadmap docs (ongoing Java→Kotlin migration)
+
+The plugin is being incrementally converted from Java to Kotlin. These are the
+per-item plans/journeys (the *why*, companion to the throwaway `~/.claude/plans/*`
+*what/when*):
+
+- **`kotlin-conversion-external-psi-plan.md`** — item 1: external/synthetic PSI +
+  typed JSON wire model for `raku-*-symbols.raku` output.
+- **`kotlin-conversion-symbol-walks-plan.md`** — item 2: the stub-vs-AST
+  symbol-contribution walks (completion/resolution/find-usages load-bearing wall).
+- **`kotlin-conversion-arity-matcher-plan.md`** — item 3: `RakuSignature` arity
+  matcher / lexical resolution.
+- **`kotlin-conversion-stub-package-journey.md`** — the `psi/stub` package conversion
+  (STUB_VERSION serialization safety; one commit per PSI kind). See also
+  `stub-building-index-queries.md`.
+
+## Operational howtos
+
+- **`bumping-supported-idea-version.md`** — releasing RIP for a new IDEA version
+  (`.versions/*`, `./gradlew buildPlugin`).
+
+## Conventions
+
+- One investigation → one Markdown file, kebab-case name by topic (`area-symptom.md`).
+- Lead with the symptom and the fix's landing point (commit/PR + test), then the root
+  cause, then the transferable principle. Optimize for an agent landing cold.
+- **Branch names in these docs are historical.** Work this session was done on
+  `2026.2-beta.3` and squash-merged to `main` via PR #47 (so original commit hashes
+  like `4aade331` are not `main` ancestors, but the changes are present). Earlier docs
+  reference branches like `2026.1-beta.2`. Trust file paths, test names, and PR
+  numbers over branch/hash references.
+- Prefer verifiable anchors: exact file paths, rule/state numbers, test class names,
+  and reproducing one-liners (`raku -e '...'`) over prose.

--- a/org/llm/traces/bumping-supported-idea-version.md
+++ b/org/llm/traces/bumping-supported-idea-version.md
@@ -1,0 +1,9 @@
+# Bumping the supported IDEA version
+
+Until RIP is available directly on the IntelliJ marketplace, it needs to be released "manually" for each new version of the IDE.
+
+There are a number of `gradle` tasks available for assisting with this process. However, theyh are not necessary for building a local plugin. 
+
+1. Edit the `.versions/idea-version` file and edit it to include the version number you want to support.
+2. Edit the `.versions/raku-beta-version` file to whatever you wish, so long as it ends in a number. The default pattern is `$ideaVersion-beta.1`
+3. `./gradlew buildPlugin`

--- a/org/llm/traces/inspection-private-role-methods.md
+++ b/org/llm/traces/inspection-private-role-methods.md
@@ -1,0 +1,61 @@
+# MissingRoleMethodInspection false-positived on private role methods
+
+**Fix:** merged to `main` via PR #47; originally `da14d6fa` on `2026.2-beta.3`.
+Regression test: `src/test/kotlin/org/raku/comma/inspection/MissingRoleMethodInspectionTest.kt`.
+
+## Symptom
+
+`MissingRoleMethodInspection` fired `Composed roles require to implement methods:
+!clone-rows` on a class that `does` a role stubbing a **private** method it didn't
+implement. In the reported case, `Math::Matrix does Math::Matrix::Util`, and
+`Util` contains `method !clone-rows { ... }` (a yada stub), which `Math::Matrix`
+does not implement.
+
+## The trap we nearly fell into
+
+This looked at first like it might be a false *negative* (a multi-file test reported
+0 problems) or an empty-`{}`-body handling bug. Both were wrong. The decisive move
+was to **ask the actual language**:
+
+```
+$ raku -e 'role R { method foo { ... } }; class C does R { }; C.new; say "ok"'
+===SORRY!=== Method 'foo' must be implemented by C because it is required by roles: R.
+
+$ raku -e 'role R { method !foo { ... } }; class C does R { }; C.new; say "ok"'
+ok
+```
+
+**Raku enforces public yada-stub role methods as hard composition requirements
+(compile error if unimplemented), but does NOT enforce private (`!`-twigil) ones.**
+A class may `does` a role that stubs a private method and compile fine without it.
+`raku -I. -MMath::Matrix -e 'say "hi"'` loading cleanly was the tell that the
+inspection, not the library, was wrong.
+
+(The earlier confusion came from a local edit that had temporarily added
+`method !clone-rows {}` to the working copy; with the real git tree, the method is
+genuinely absent — and correctly so, because Raku doesn't require it.)
+
+## Fix
+
+`MissingRoleMethodInspection.gatherRoleStubs` now skips private methods entirely when
+collecting methods-to-implement:
+```kotlin
+if (maybeMethod.isPrivate) continue   // RakuRoutineDecl already exposes isPrivate()
+```
+A private method is never a requirement, and also can never *satisfy* a public
+requirement (different namespaces), so excluding them outright is correct.
+
+## Principle
+
+When an inspection encodes a language rule, verify the rule against the compiler
+itself (`raku -e '...'`) before assuming the inspection or the user's code is at
+fault. A one-line rakudo invocation settled a question that source-reading and PSI
+inspection had left ambiguous.
+
+## Regression coverage (direct-invocation, not checkHighlighting)
+
+`MissingRoleMethodInspectionTest` instantiates the inspection and asserts on
+`ProblemsHolder.results`, deliberately bypassing the broken `checkHighlighting`
+pipeline (see `test-harness-and-environment.md`). Cases: public stub missing → fires;
+public stub implemented (normal and empty `{}` body) → clean; private stub missing →
+must NOT fire; private stub implemented → clean.

--- a/org/llm/traces/kotlin-conversion-arity-matcher-plan.md
+++ b/org/llm/traces/kotlin-conversion-arity-matcher-plan.md
@@ -1,0 +1,116 @@
+# Arity matcher / lexical resolution: exploration + plan (roadmap item 3)
+
+## Exploration report (full, from the research agent)
+
+### 1. `RakuSignature.java`
+
+Path: `src/main/java/org/raku/comma/psi/RakuSignature.java` (231 lines)
+
+Full interface member listing:
+
+- `String summary(RakuType type)` — abstract (line 11)
+- `RakuParameter[] getParameters()` — abstract (line 12)
+- `default SignatureCompareResult acceptsArguments(PsiElement[] argsArray, boolean isCompleteCall, boolean isMethodCall)` — lines 14-105 — **the arity matcher**
+- `default String prepareParamName(String variableName)` — lines 107-128 (strips sigils/twigils/`!`/`?` off a named-parameter variable name for comparison)
+- `default int eatPositionalSlurpy(...)` — lines 130-139
+- `default void eatNamedSlurpy(...)` — lines 141-152
+- `default void failMatch(SignatureCompareResult result, Pair<Integer, MatchFailureReason>... failures)` — lines 154-159
+- `default void categorizeArguments(List<PsiElement> arguments, List<PsiElement> positionalArgs, Map<String, PsiElement> namedArgs)` — lines 161-169 (splits call arguments into positional vs. `RakuColonPair`/`RakuFatArrow` named args)
+- `enum MatchFailureReason` — lines 171-182: `NOT_ENOUGH_ARGS, TOO_MANY_ARGS, SURPLUS_NAMED, TYPE_MISMATCH, CONSTRAINT_MISMATCH, MISSING_REQUIRED_NAMED` (plus a mutable `@Nullable public String name` field bolted onto the enum for the missing-named-arg's name — flagged below as a real bug, not just a smell)
+- `class SignatureCompareResult` — lines 184-230, a small mutable result object (`isAccepted`, `argToParam` map, `failures` map, `nextParameterIndex`) with getters/setters.
+
+**The arity-matching default method** (lines 14-105) walks parameters left to right, splitting call arguments into positional/named buckets first (`categorizeArguments`), then for each parameter: a leading `|`/`|c` parameter accepts everything and short-circuits; positional-slurpy eats all remaining positional args; named-slurpy eats all remaining named args; otherwise matches the next positional arg or the named arg matching `prepareParamName(variableName)`, and records `NOT_ENOUGH_ARGS`/`MISSING_REQUIRED_NAMED` failures for required-but-missing parameters when `isCompleteCall`. After the loop, surplus named args (unless it's a method call, which tolerates them) and surplus positional args are flagged.
+
+**Call sites for `acceptsArguments` (every one, repo-wide):**
+
+1. `src/main/java/org/raku/comma/inspection/inspections/CallArityInspection.kt:61`
+2. `src/main/java/org/raku/comma/RakuParameterInfoHandler.java:151`
+3. `src/main/java/org/raku/comma/cro/template/CroTemplateParameterInfoHandler.java:62` — calls the *sibling* `CroTemplateSignature.acceptsArguments` (a separate, independent matcher for Cro templates, not sharing code with `RakuSignature`'s — see item 7 below)
+4. `src/test/kotlin/org/raku/comma/signatures/RakuSignatureComparatorTest.kt:33` — direct unit test
+5. `tests/edument/rakuidea/signatures/RakuSignatureComparatorTest.java:22` — legacy duplicate under a `tests/` tree that is **not wired into `build.gradle.kts`/`settings.gradle.kts`** (no sourceSet points at it; last touched Sep 2024) — dead scaffolding, safe to ignore.
+
+Implementors of `RakuSignature`: `RakuSignatureImpl` (native PSI, Java, adds no logic beyond the interface) and `ExternalRakuSignature.kt` (already converted in item 1) — both get `acceptsArguments` for free via the default method.
+
+### 2. `RakuPsiElement.java`
+
+Path: `src/main/java/org/raku/comma/psi/RakuPsiElement.java` (183 lines). 12 default methods: `getEnclosingRakuModuleName` (28-51), `resolveLexicalSymbol` (53-57), `resolveLexicalSymbolAllowingMulti` (59-64), `getLexicalSymbolVariants` (66-70), `applyExternalSymbolCollector` (72-97), `applyLexicalSymbolCollector` (99-110), `inferType` (112-115), `getSelfType` (117-145), `skipWhitespacesBackward`/`Forward` (147-167), `collectPodAndDocumentables` (169-177), `inferEffects` (179-182).
+
+Call-site survey: lexical-resolution consumers are **almost entirely Java** reference classes (`RakuIsTraitReference`, `RakuRegexCallReference`, `RakuTypeNameReference`, `RakuMethodReference`, `RakuSubCallReference`, `RakuVariableReference`, `RakuOpReference`, plus refactoring handlers) — roughly 20+ Java call sites vs. only 4-5 Kotlin ones (`UndeclaredVariableInspection.kt`, `RakuProjectSdkService.kt`, `ExternalRakuPackageDecl.kt`, `RakuPackageDeclImpl.kt`, one test).
+
+### 3. `RakuParameter.java` and implementations
+
+Interface (28 lines, all abstract, no default methods): `summary`, `getVariableName`, `getInitializer`, `isPositional`, `isNamed`, `getWhereConstraint`, `getValueConstraint`, `isSlurpy`, `isRequired`, `isOptional`, `isExplicitlyOptional`, `isCopy`, `isRW`, `isRaw`, `equalsParameter`.
+
+Facts the matcher actually consults: `parameter.getText()` (leading `|` check), `isPositional()`, `isSlurpy()`, `isOptional()`, `isNamed()`, `getVariableName()`.
+
+Two implementations, semantics compared and confirmed aligned:
+- `RakuParameterImpl.java` (native PSI, 300 lines) — reads quantifier tokens/child PSI (`PARAMETER_QUANTIFIER`, `RakuNamedParameterImpl`, `RakuParameterDefault`).
+- `ExternalRakuParameter.kt` (already converted, item 1) — reads prefix/suffix off the raw name string (`*%`, `:`, `*`, `+`, `!`, `?`).
+One real difference: native `isOptional()` also treats presence of a default-value initializer as optional; `ExternalRakuParameter` has no initializer concept (always null) so that trigger is inapplicable there — not a bug, just a different substrate with fewer ways to be optional.
+
+### 4. `CallArityInspection` and other consumers
+
+`src/main/java/org/raku/comma/inspection/inspections/CallArityInspection.kt` (125 lines, already Kotlin) does not reimplement matching — it resolves the call to candidate `RakuRoutineDecl`s, calls `signature.acceptsArguments(args, true, element is RakuMethodCall)` per candidate (line 61), and turns `MatchFailureReason` values into problem annotations. For `MISSING_REQUIRED_NAMED` it reads `reason.name` (line 87) — the mutated-enum-singleton field described below.
+
+`RakuParameterInfoHandler.java:151` also just calls `acceptsArguments` directly (for the parameter-info popup, doesn't touch `.name`). `CroTemplateParameterInfoHandler.java:62` uses the independent `CroTemplateSignature.acceptsArguments`.
+
+### 5. Existing test coverage
+
+- `src/test/kotlin/org/raku/comma/signatures/RakuSignatureComparatorTest.kt` — 9 test methods covering positional/named/slurpy/surplus/required-named/incomplete-call cases. Strong existing harness; reused almost as-is for the extraction.
+- `tests/edument/rakuidea/signatures/RakuSignatureComparatorTest.java` — dead duplicate (see above), ignore.
+- `CallArityInspection`: no dedicated test class; exercised via `AllRakuInspections.kt` plus two methods in the large `AnnotationTest.kt` (`testCallArityMismatchAnnotating` line 1132, `testCallArityMismatchAnnotatingOnAccessorCall` line 1163) using `testData/annotation/CallArity.pm6` / `CallArityExtended.pm6`.
+- `src/test/kotlin/org/raku/comma/parameterInfo/RakuParameterInfoTest.kt` — 9 tests.
+- `src/test/kotlin/org/raku/comma/reference/GoToDeclarationTest.kt` — 25 tests, primary lexical-resolution coverage (all indirect, through PSI reference resolution — no unit test targets `applyLexicalSymbolCollector`/`applyExternalSymbolCollector` directly).
+
+### 6. Other large default-method interfaces in `org.raku.comma.psi` (for a future session)
+
+`RakuPsiDeclaration.java` (5 defaults, 87 lines — `getGlobalName()` walks up enclosing packages), `RakuPsiScope.java` (3 defaults, 58 lines — BFS-shaped, tightly coupled to the lexical-resolution walk, a natural pairing with a future `RakuPsiElement` conversion), `RakuDocumented.java` (2 defaults, 94 lines — self-contained doc-comment-gathering walk), `RakuSignatureHolder.java` (2 defaults, 39 lines — thin, direct consumer of `RakuSignature.summary`).
+
+**Second independent arity matcher**: `src/main/java/org/raku/comma/cro/template/psi/CroTemplateSignature.java` (94 lines) reimplements the same algorithm shape for Cro web-template parameters against `CroTemplateParameter`, reusing `RakuSignature.SignatureCompareResult`/`MatchFailureReason` as data types only. Not touched by this item; noted for later generalization if ever wanted.
+
+### 7. Build facts
+
+No new Kotlin build config needed — Kotlin 2.3.20 + existing `kotlin.stdlib.default.dependency=false` setup (from items 1-2) is sufficient. This is pure logic extraction, no serialization involved.
+
+---
+
+## Design decision: extract, don't convert the interface
+
+**`RakuSignature.java` and `RakuPsiElement.java` stay Java.** Converting either to a Kotlin interface risks a real Java-interop hazard: Kotlin interface default methods compiled in the project's current mode (no `-Xjvm-default` setting found in `build.gradle.kts` → Kotlin's `disable` default) generate an abstract method plus a separate `$DefaultImpls` companion, and **Java classes implementing the interface do not automatically inherit the Kotlin-compiled default** — they'd need an explicit override or hit `AbstractMethodError` at runtime. `RakuSignatureImpl.java` (Java, relies on the inherited default today) and the ~20+ Java implementors/callers of `RakuPsiElement` would all be at risk. No existing Kotlin interface with a default method implemented by a Java class exists anywhere in this codebase yet, so there's no established, verified-safe precedent to build on.
+
+Per the roadmap's own phrasing — "the arity matcher... should become a **standalone, directly unit-testable Kotlin class**" — extraction was always the intended shape, not a file-for-file interface conversion. So:
+
+1. **New file `RakuArityMatcher.kt`** (same package, `org.raku.comma.psi`, as a `object` with `@JvmStatic` — the established idiom in this codebase, e.g. `RakuSdkUtil`) holds the full algorithm: `acceptsArguments`, `prepareParamName`, `eatPositionalSlurpy`, `eatNamedSlurpy`, `failMatch`, `categorizeArguments`, all as private helpers except the public entry point.
+2. **`RakuSignature.java`'s default `acceptsArguments` shrinks to a one-line delegation**: `return RakuArityMatcher.acceptsArguments(this, argsArray, isCompleteCall, isMethodCall);`. The other five default methods are deleted from the interface entirely (nothing outside `RakuSignature.java` called them — verified by repo-wide grep). `MatchFailureReason` and `SignatureCompareResult` stay as nested types on `RakuSignature.java` (plain data types, not default methods — zero interop risk) so every existing import/reference (`RakuSignature.MatchFailureReason`, `RakuSignature.SignatureCompareResult`) keeps working unchanged.
+3. **`RakuPsiElement.java` is left for a later session.** Its default methods are individually small (2-10 lines) and don't "hide" complexity the way the 90-line arity matcher did — the real value in touching it is bundling it with `RakuPsiScope.java` (structurally the same BFS-over-scopes shape) as a dedicated, larger interop-risk-assessed conversion, not something to rush alongside this item.
+
+## A real bug found and fixed along the way
+
+`RakuSignature.java:81-83` (current, pre-fix):
+```java
+MatchFailureReason failReason = MatchFailureReason.MISSING_REQUIRED_NAMED;
+failReason.name = parameter.getVariableName();
+failMatch(result, new Pair<>(posArgIndex, failReason));
+```
+`MatchFailureReason.MISSING_REQUIRED_NAMED` is a **single shared enum instance**. Setting `.name` on it mutates global state: if a signature has two missing required named parameters, the second `failMatch` call overwrites `.name` before `CallArityInspection.kt:87` ever reads it, so **both** failures report the same (last) parameter's name. This is exactly the "logic hides from review" failure mode the roadmap called out — it was invisible inside a one-line-looking mutation buried in a 90-line default method.
+
+**Fix**: move the per-failure name out of the enum and into `SignatureCompareResult`, keyed by argument index — the same place every other piece of per-failure detail already lives:
+```java
+// SignatureCompareResult, new members
+private final Map<Integer, String> failureDetails = new HashMap<>();
+public void setFailureDetail(int argIndex, @Nullable String detail) { if (detail != null) failureDetails.put(argIndex, detail); }
+@Nullable public String getFailureDetail(int argumentIndex) { return failureDetails.getOrDefault(argumentIndex, null); }
+```
+`MatchFailureReason` loses its mutable `name` field entirely (confirmed no other reader: only `CallArityInspection.kt:87` used `.name`; `CroTemplateSignature.java` never sets or reads it). `CallArityInspection.kt` changes to `result.getFailureDetail(i)`. A new characterization test in `RakuSignatureComparatorTest.kt` pins two simultaneous missing required named parameters resolving to two distinct, correct detail strings — impossible to assert correctly before this fix.
+
+## Commit plan
+
+- **Single commit** (this item is small enough not to need the multi-commit staging of items 1-2): add `RakuArityMatcher.kt`, shrink `RakuSignature.java` to the two abstract methods + one-line delegating default + the two nested types (with the `failureDetails` addition and `name`-field removal), update `CallArityInspection.kt`'s one read site, extend `RakuSignatureComparatorTest.kt` with the two-missing-named-args regression case.
+- Verify: `RakuSignatureComparatorTest`, `RakuParameterInfoTest`, `AnnotationTest` (arity-specific methods at minimum, ideally the full class since it's already a known-flaky-adjacent suite), then a full-suite run for the final sign-off against the established baseline (6 pre-existing failures + roaming leak flake).
+
+## Must not change
+
+- `RakuSignature`/`CroTemplateSignature` public API shapes (`acceptsArguments` signature, `SignatureCompareResult`/`MatchFailureReason` as nested types with their existing getters).
+- `RakuParameter` interface and both implementations (native `RakuParameterImpl.java`, `ExternalRakuParameter.kt`) — untouched, the matcher only consumes their existing facts.
+- `CroTemplateSignature.java` — independent, not refactored to share the new class in this pass.
+- The `RakuSignatureComparatorTest.kt` existing 9 assertions (behavior-preserving except the one bug fix, which has no existing test pinning the old broken behavior to break).

--- a/org/llm/traces/kotlin-conversion-external-psi-plan.md
+++ b/org/llm/traces/kotlin-conversion-external-psi-plan.md
@@ -1,0 +1,76 @@
+# Convert external/synthetic PSI layer to Kotlin (roadmap item 1)
+
+## Context
+
+Next step of the agreed Kotlin-conversion roadmap, right after the full suite went green (1034/1034, commit `ad192073`, branch `2026.1-beta.2`). The `psi/external/` package (7 Java files) plus `sdk/RakuExternalNamesParser.java` is the highest-value target because conversion here also fixes two structural problems:
+
+1. **Implicit wire contract.** The JSON emitted by `raku-module-symbols.raku` / `raku-core-symbols.raku` (keys `k,n,t,d,m,s,r,p,x,b,a,mro,key,nn,rakudo`) is parsed with `org.json` string lookups; the contract exists only implicitly on both sides. A typed kotlinx.serialization model (house style: `ExternalMetaFile.kt`) makes it explicit and would have surfaced the "methods silently missing from role entries" class of bug immediately.
+2. **Duplicated stub boilerplate.** ~60 no-op/throw overrides live in `RakuExternalPsiElement.java` (base for the 5 element classes) and a second, independent ~65-method copy inline in `ExternalRakuFile.java`.
+
+Build is ready: Kotlin 2.3.20, `kotlin("plugin.serialization")` applied, `kotlinx-serialization-json:1.7.3` on classpath.
+
+## Key design decisions
+
+### JSON model: sealed interface + `JsonContentPolymorphicSerializer` on `"k"` — not `classDiscriminator`
+
+`classDiscriminator` can't work: several `"k"` values map to one shape (`"m"/"s"/"r"` → routine, `"mm"/"c"/"ro"` → package), the routine shape also appears *nested* (non-polymorphically) inside package `"m"` arrays, and the code needs the raw `k` string (`getRoutineKind`). A `JsonContentPolymorphicSerializer` selecting on `k` handles all of this and leaves `k` readable as a plain property.
+
+New file `src/main/java/org/raku/comma/sdk/ExternalSymbolsJson.kt`:
+
+- `sealed interface ExternalSymbolEntry { val k: String; val n: String }` with `@Serializable` data classes: `NativeTypeEntry` (`k,n,t`), `VariableEntry` (`k,n,t,d?`), `EnumOrSubsetEntry` (`k,n,t,d?`), `RoutineEntry` (`k,n,m:Int,s:SignatureJson,d?,x?,p:Boolean=false,rakudo:Boolean=false`), `PackageEntry` (`k,n,t,b,key?,d?,mro:List<String> = emptyList(),m:List<RoutineEntry>? = null,a:List<AttributeEntry> = emptyList()`).
+- `AttributeEntry(n,t,d?)`, `SignatureJson(r, p:List<ParameterJson> = emptyList())`, `ParameterJson(n,t,nn:List<String> = emptyList())`.
+- `PackageEntry.m` **must be nullable**: `"mm"` entries emit literal `"m":null` (verified in `CORE.fallback`). Parser uses `entry.m.orEmpty()`.
+- Local lenient config per house style: `Json { ignoreUnknownKeys = true; isLenient = true }`.
+- Decode the top-level array element-by-element: unknown `k` → silent skip (matches Java's switch default); decode failure → warn + skip that element. **This is the only permitted behavior delta** vs Java (which aborts the remainder of the array on first error) — strictly more tolerant; covered by a test and called out in the commit message.
+
+### PSI structure: keep the base class, reject interface delegation
+
+`RakuExternalPsiElement` becomes an `abstract` Kotlin class, same FQN (it's `instanceof`-checked in `RakuInspection.kt:25`, `RakuDocumentationProvider.java`, `RakuLineMarkerProvider.java`, `RakuParameterInfoHandler.java` — the named supertype must survive). Delegation loses: identity-returning members (`getContainingFile()`/`copy()`/`getOriginalFile()` return `this`) are delegation traps, and every project-dependent method would need re-overriding on top of the delegate anyway. `ExternalRakuFile` stays a standalone class implementing `RakuFile` with a clearly-marked region of one-line expression-body stubs; no second stub base for a single class.
+
+## Commit plan (one subsystem per commit; full suite green after each)
+
+Order is inverted from "parser first": the parser hands `org.json.JSONObject` into `ExternalRakuRoutineDecl`/`ExternalRakuSignature` constructors, so converting elements first (keeping `JSONObject` params temporarily) means the later parser commit changes constructor types in already-Kotlin files instead of editing Java.
+
+### Commit 0 — Characterization tests (safety net)
+New `src/test/kotlin/org/raku/comma/sdk/RakuExternalNamesParserTest.kt` extending `CommaFixtureTestCase`, using the **String** parser constructor (survives the API change) and asserting only through PSI interfaces (`RakuRoutineDecl`, `RakuPackageDecl`, …):
+- Per-kind snippets: `"n"`, `"v"` (docs `"a\nb"` → `getDocsString() == "a<br>b"`), `"m"/"s"/"r"` (scope has/our; `m:0`→only, `m:1`→multi; `s.r="Str:D"` → return type `Str`; `x`→deprecated; `p`→pure; `rakudo`→implementation detail), `"e"/"ss"` (→ packageKind class), `"mm"` then `"c"` (metaclass linked via `metamodelCache[packageKind]`; `"m":null` tolerated), nested routines + attributes (MOP contribution: `.method` aliases, `!private` gating, `$.attr` accessors).
+- Parameter semantics via signature params: `*%_`, `:$x`, `$x?`, `$x!`, `nn` → `getVariableNames()`.
+- Garbage input → empty result; `"[]"` → empty; `CORE.fallback` round-trip pinning exact symbol count + resolving `Any` with satisfied multiness routing.
+- Do NOT yet add a "bad element mid-array" test (expected behavior changes in Commit B).
+
+### Commit A — Convert base + 5 element classes
+`RakuExternalPsiElement`, `ExternalRakuPackageDecl`, `ExternalRakuRoutineDecl`, `ExternalRakuVariableDecl`, `ExternalRakuParameter`, `ExternalRakuSignature` → Kotlin. Same FQNs, same API; `org.json.JSONObject` ctor params kept temporarily in RoutineDecl/Signature. Zero caller changes.
+
+### Commit B — Typed model + parser conversion
+Add `ExternalSymbolsJson.kt`; convert `RakuExternalNamesParser` to Kotlin. API (parser is called **only from Kotlin** — `RakuProjectSdkService.kt`, `CoreSettingDiagTest.kt`):
+- Constructors `(project, file, jsonText: String)` and `(project, file, entries: List<ExternalSymbolEntry>)`; **drop** the `JSONArray` overload.
+- `companion object { fun tryDecode(text: String): List<ExternalSymbolEntry>? }` replaces the "parse-to-validate before caching" idiom at `RakuProjectSdkService.kt:433-440`.
+- Keep `parse()` fluent, `result()`, `getPackages()` (dead but trivial).
+- Swap `ExternalRakuRoutineDecl`/`ExternalRakuSignature` ctor params `JSONObject → SignatureJson`; update `RakuProjectSdkService.kt` call sites (~328, 367, 433-440) and `CoreSettingDiagTest.kt:10-14`; drop `org.json` imports there.
+- Add the "bad element skipped, rest survives" test.
+
+### Commit C — Convert `ExternalRakuFile`
+No API change (`RakuFileImpl.java:376` and `RakuProjectSdkService.kt` construct it identically).
+
+## Risk flags per file (the four known conversion bug patterns apply throughout)
+
+- **RakuExternalPsiElement**: keep `override fun getDocsString()` (dropping it falls back to `RakuDocumented`'s default which walks real PSI → crash on synthetics); `setDocs` keeps `\n→<br>`; null-returning stubs keep nullable types, **never `!!`**; mutators throw `IncorrectOperationException`, not `TODO()`.
+- **ExternalRakuPackageDecl**: preserve three verified quirks verbatim — (1) getters pool computed only in the long ctor from `attrs`, and `setAttributes()` (which the parser actually uses) does *not* recompute it, so getter suppression never fires at runtime — do not "fix"; (2) no `isSatisfied()` check inside the MRO loop (only after routines/attrs loops); (3) `getSignature()` stays a TODO stub. `setName` keeps assignment *and* returns null. `inferType()` uses `myType` (JSON `t`), not `myName`.
+- **ExternalRakuRoutineDecl**: `:D`/`:U` trim is conditional single-suffix drop; keep dead `"sm"`/`"submethod"` branches; `offerSymbol` vs `offerMultiSymbol(sym, false)` routing — offers are statements (discarded-return-value pattern); avoid a clashing `signature` property vs `getSignature(): String`; `isImplementationDetail` as `var` (read property-style from `RakudoImplementationDetailInspection.kt`).
+- **ExternalRakuVariableDecl**: guard order + `isSatisfied` early-returns between offers; `Char + String` concat must not become arithmetic.
+- **ExternalRakuParameter**: `NAME_PATTERN = "([|$@%&\\w+...])"` regex into a companion; prefix/suffix flag logic (`*%`, `:`, `*`, `+`, `!`, `?`) verbatim; keep `getText()` override returning `myName`.
+- **ExternalRakuSignature**: `summary()` string shape exact (`", "` join, `" --> "` return); intentionally no `getName()` override.
+- **RakuExternalNamesParser**: single-pass order-dependence — `"mm"` fills `metamodelCache` before `"c"/"ro"` looks up by `psi.packageKind` (key is `"class"`/`"role"`, counterintuitive — do **not** "correct" to `entry.key`); `"mm"` sequence exactly cache→setName(key)→externalClasses→result; top-level routine scope `k=="m" ? "has" : "our"`, nested always `"has"`; `"e"/"ss"` constructed with kind `"c"`, base `"A"`.
+- **ExternalRakuFile**: `contributeGlobals` multiness routing + `isSatisfied` after *every* offer; identity returns `this` (`getContainingFile`/`copy`/`getOriginalFile`); `getName()`/`toString()` = `myFile.name` (docs provider compares to `SETTING_FILE_NAME`; `CallArgGotoElementProviderBase` does `startsWith("Cro::WebApp::Template")`); keep exception split (file stubs → `UnsupportedOperationException`, except `checkSetName` → `IncorrectOperationException`); `myViewProvider` stored nullable, returned via `!!` in the `@NotNull` override (noted in commit).
+
+## Must NOT change
+
+Wire contract keys and both Raku emitter scripts; `CORE.fallback`; FQNs of all converted classes; `build.gradle.kts` (org.json stays — used by other subsystems); `RakuProjectSdkService` caching/threading flow (only call shapes); the behavioral quirks listed above.
+
+## Verification
+
+Every test shell needs `eval "$(rakubrew init Zsh)"` first, else all tests fail in setUp.
+
+- After Commit 0 and each of A/B/C: full `./gradlew test` (expect 1034 + new tests green; known pre-existing order-dependent leak-detector flake may fire on an arbitrary late test).
+- Targeted while iterating: `./gradlew test --tests "org.raku.comma.sdk.RakuExternalNamesParserTest"` and `--tests "org.raku.comma.CoreSettingDiagTest"`.
+- After Commit C additionally: `./gradlew test --tests "org.raku.comma.completion.*" --tests "org.raku.comma.docs.*"` (heaviest exercisers of `contributeGlobals`/MOP paths).

--- a/org/llm/traces/kotlin-conversion-stub-package-journey.md
+++ b/org/llm/traces/kotlin-conversion-stub-package-journey.md
@@ -1,0 +1,217 @@
+# Converting `psi/stub` to Kotlin: journey notes
+
+Working notes on the `psi/stub` package conversion (roadmap item: the last
+"mostly mechanical, still needs care" item). Companion to the plan at
+`~/.claude/plans/cheeky-napping-nova.md` — this doc is the *why*, the plan is
+the *what/when*. ~56 files, one commit per PSI kind (interface + impl +
+element type together), lightest-risk kinds first, file-level machinery
+(where `STUB_VERSION` lives) last.
+
+## The shape of the package
+
+Four layers, each with a distinct job:
+
+- **Stub interfaces** (`RakuConstantStub`, `RakuVariableDeclStub`, ...) — the
+  public contract. Tiny: a handful of accessor methods.
+- **`*StubImpl` classes** (`psi/stub/impl/`) — dumb data holders. Each extends
+  `StubBase<T>`, stores a few constructor-supplied fields, returns them.
+- **`*StubElementType` classes** — the only place serialization actually
+  happens. `createStub`/`createPsi` (stub ↔ real PSI), `serialize`/
+  `deserialize` (stub ↔ bytes), `indexStub` (stub → search index), and
+  `shouldCreateStub` (should this AST node get a stub at all).
+- **Stub indices** (`psi/stub/index/`) — `StringStubIndexExtension`
+  subclasses, each with its own independent `INDEX_VERSION`.
+
+The interfaces form a small hierarchy: `RakuDeclStub<T>` (scope +
+exported-ness) is the base for most declaration kinds; `RakuTypeStub<T>`
+extends it and adds `getGlobalName()`/`getLexicalName()` as real default
+methods (not just accessors) for the three package-like kinds (`class`/
+`role`/`grammar` via `RakuPackageDeclStub`, `enum`, `subset`).
+
+## Why `StringRef` exists
+
+`StubOutputStream`/`StubInputStream` aren't just wrapped `DataOutputStream`/
+`DataInputStream` — they're constructed with an `AbstractStringEnumerator`:
+
+```java
+public StubOutputStream(OutputStream out, AbstractStringEnumerator enumerator)
+public StubInputStream(InputStream in, AbstractStringEnumerator enumerator)
+```
+
+That enumerator is a shared, persistent string-interning table. `writeName(String)`
+doesn't write the string's bytes at all if it's seen that exact string before —
+it writes a small integer ID into the enumerator's table instead. `readName()`
+returns a `StringRef`, a *lazy* handle that resolves to the real string
+(`getString()`) either immediately or by looking up the ID later. This is why
+`writeName`/`readName` are paired (not `writeUTFFast`/`readUTFFast`, the other
+pair on those classes, which do plain modified-UTF-8 with no interning).
+
+The tradeoff `writeName` is for: package/module/variable/routine *names* repeat
+constantly across a codebase's stub trees (`Str`, `Int`, `$self`, `new`, ...),
+so interning them once is a real space win. Free-text payloads that are
+unlikely to repeat (like `RakuSubCallStub`'s Cro-framework metadata values)
+use `writeUTFFast`/plain `writeUTF` instead — nothing to intern.
+
+Practical fallout for the conversion: every `deserialize()` that calls
+`dataStream.readName()` gets back a `StringRef?`, not a `String?` — Kotlin
+sees the nullable platform return type honestly, where Java's un-annotated
+`StringRef` return let call sites pretend it couldn't be null. Every
+`deserialize()` in this package has to decide, explicitly, what "the name
+storage doesn't have this ID" actually means for that field — see below.
+
+## The recurring interop trap: Kotlin doesn't auto-property its own funs
+
+Kotlin maps a **Java** getter (`String getFoo()`) to a synthetic property
+(`.foo`) automatically. It does **not** do this for a getter-shaped function
+it compiles from **Kotlin source** — `fun getFoo(): String` stays a plain
+function, callable only as `.getFoo()`.
+
+Existing Kotlin call sites in this codebase (written back when these stub
+interfaces were Java) universally used the property form — `stub.moduleName`,
+`node.scope`, `entry.value`, etc. — because that's what the synthetic mapping
+made idiomatic at the time. The moment an interface converts, every such call
+site breaks, and — this was the surprising part — it breaks **transitively**:
+converting just `RakuDeclStub` (the base) broke property-syntax access to
+`.scope`/`.isExported` through five different *still-Java* subtypes
+(`RakuVariableDeclStub`, `RakuPackageDeclStub`, `RakuRoutineDeclStub`,
+`RakuEnumStub`, `RakuSubsetStub`), because the mapping is keyed on where the
+method is *actually declared*, not which interface you access it through.
+
+Decided early (during `RakuTraitStub`, the first conversion) to keep every
+converted interface method as a plain `fun getX(): T`, matching the
+already-established house style from `RakuSubCallStubElementType.kt` (the one
+file converted before this effort started), rather than switching to Kotlin
+`val`/property declarations that would have stayed call-site-compatible with
+zero fixes. Consistency within the package won out over saving some grep-and-fix
+effort — the compiler catches every break loudly (never a silent bug), so the
+cost of the stricter style is bounded and visible, not a real risk.
+
+Practical process note this produced: grep **both** `src/main/` and
+`src/test/` for property-syntax usage before compiling each commit. Missed
+`src/test/` twice early on (commits 3 and 4) because Gradle's incremental
+Kotlin compilation didn't re-flag the break until a later, unrelated
+recompile — don't trust "it compiled last time" as proof a test file wasn't
+affected by an interface change since.
+
+## Nullability: matching the existing contract, not just the wire format
+
+Every `deserialize()` in this package has at least one spot where the
+original Java quietly allowed a code path Java's type system couldn't see
+(a `String`-typed field that could actually hold `null`, a `List<String>`
+whose loop could `add(null)`). Kotlin forces each of these into the open.
+The resolution wasn't one rule — it was a case-by-case judgment call, weighed
+against **what the surrounding code already assumes**:
+
+- **`RakuTraitStub`/`RakuTypeNameStub`** — Java dereferenced the read value
+  with no null check at all (`ref.getString()`, `typename.toString()`). This
+  is "null was never a real possibility, just unchecked" — faithfully ported
+  as a crash-on-null via `Objects.requireNonNull<StringRef?>(...)`, *not*
+  Kotlin's bare `!!` (matching the one pre-existing Kotlin precedent's style)
+  and *not* a new silent null-tolerant path (Kotlin's `Any?.toString()` is
+  null-safe by default and would have silently turned a missing name into the
+  literal string `"null"` — a real behavior change hiding in what looks like
+  a mechanical port).
+- **`RakuUseStatementStub`** — Java's ternary (`ref == null ? null : ...`)
+  is explicit, deliberate null-tolerance, and the consuming PSI code
+  (`RakuUseStatementImpl.getModuleName(): String?`) already treated it as
+  legitimately nullable. Went nullable (`String?`) all the way through —
+  contained to one field, cheap to do faithfully.
+- **`RakuNeedStatementStub`** — same per-element null-tolerance shape as
+  `UseStatementStub`, but `GlobalsFacts.Need(val moduleNames: List<String>)`
+  and its consumers already assume non-null elements. Making the list
+  `List<String?>` would have rippled into unrelated code for a rare
+  corrupted-stream edge case. Chose containment: kept `List<String>`
+  everywhere, used `Objects.requireNonNull` per element instead.
+- **`RakuConstantStub`** — the Java field was `@Nullable`-annotated. Not a
+  judgment call at all; just carried the existing contract through as
+  `String?`.
+- **`RakuRegexDeclStub`** — Java used `assert regexNameRef != null;` (a
+  statement that's a no-op unless `-ea` is set) before dereferencing. Read as
+  "this is genuinely expected to always be present," not "null is tolerated"
+  — ported the same way as Trait/TypeName's unchecked case.
+
+The general principle that fell out of this: **prefer the option with the
+smallest blast radius that's still honest about the one call site that
+matters**, rather than mechanically propagating nullability outward just
+because the wire format could theoretically produce it. A rare
+corrupted-index edge case doesn't justify making a dozen unrelated call sites
+handle a null they've never had to think about.
+
+One case forced a fix at the call site rather than in the stub itself:
+`RakuSubCallStub.getAllFrameworkData()` had to become `Map<String?, String?>`
+to match what the *already-Kotlin* `RakuSubCallStubElementType.kt` actually
+constructs (`HashMap<String?, String?>`) — that surfaced two downstream
+consumers (`indexStub`, `RakuSubCallImpl.getPresentation()`) copying entries
+into a `MutableMap<String, String>` without a null check. Used `!!` there,
+same reasoning as the roadmap's earlier `RakuPsiElement` conversion: making a
+pre-existing implicit assumption explicit is a faithful fix, not a new
+defensive branch.
+
+## `STUB_VERSION` discipline
+
+One constant (`RakuFileElementType.STUB_VERSION`, currently 29) governs the
+serialized shape of the *entire* stub tree. Bump it and every user's cached
+index silently invalidates on next open; forget to bump it when the shape
+really changed and you get phantom/stale data with no error anywhere. There's
+no test that catches a wrong call either way (closed part of that gap with
+`RakuStubSerializationTest.kt`'s round-trip test, added as commit 0, but it
+only catches *this session's* regressions, not a genuine future shape change
+someone forgets to version-bump).
+
+Policy: this conversion is a pure transliteration — same fields, same order,
+same wire types — so it should never need a bump. If a file ever seems to
+*need* an actual shape change to be correct in Kotlin, that's a stop-and-ask
+moment, not a unilateral call.
+
+## Real findings along the way (not fixed, just characterized)
+
+- **`RakuTypeStub.getGlobalName()`/`getLexicalName()`'s "my" branch is dead
+  code for packages.** Both walk ancestor stubs looking for a
+  `RakuScopedDeclStub` with `getScope() == "my"`. But
+  `RakuScopedDeclStubElementType.shouldCreateStub()` only ever creates that
+  wrapper for `"has"` or exported-`"our"` declarations — `"my"` is explicitly
+  excluded (`if (!scope.equals("our")) return false;`). So `my class Foo {}`
+  is indistinguishable, at the stub level, from plain `class Foo {}`. Pinned
+  with a test (`testMyScopedPackageBehavesLikeOurForNaming`); not fixed —
+  out of scope for a conversion, and worth a deliberate look on its own.
+- **`CroTemplatePartStubIndex`'s `getInstance()` returned the wrong type**
+  (`RakuAllRoutinesStubIndex` instead of itself) — a copy-paste bug, confirmed
+  dead via grep (`getInstance()` is never called; the index is only reached
+  through plugin.xml's no-arg-constructor instantiation). Ported verbatim in
+  the stub-indices commit, then fixed as its own separately-labeled final
+  commit (18/19), not silently folded into the mechanical port.
+
+## Process notes
+
+- One commit per PSI kind, interface+impl+element-type together (a "vertical
+  slice") — not one commit for "all interfaces," then "all impls," etc. Each
+  commit stays independently bisectable and revertable.
+- Verification cadence: fast in-process stub tests
+  (`org.raku.comma.stub.*`, no real file I/O) after every commit; the fuller
+  set (`GoToDeclarationTest`, `ModuleNameCompletionTest`,
+  `MultiModuleCompletion`, `cro.*`) as a checkpoint every ~5 commits rather
+  than every single one, to keep iteration fast — the fast suite already
+  exercises every changed serialize/deserialize path, and multi-module/
+  index-persistence coverage is much slower per-run for comparatively little
+  marginal signal at this granularity.
+- `org.raku.comma.cro.annotation.AnnotationTest`'s two failures during the
+  5-commit checkpoint are a pre-existing, unrelated environment issue (a
+  `PluginException` from the bundled Kotlin plugin's
+  `KotlinScriptDefinitionCodeVisionProvider`, traced back to the 2026.1→2026.2
+  SDK bump earlier this session) — hits any test routing through
+  `checkHighlighting()`/`doHighlighting()`, confirmed by reproducing it against
+  completely untouched test classes. Not this conversion's doing.
+- For the final two commits (17, 18 — file-level machinery and the
+  `CroTemplatePartStubIndex` fix), a full `./gradlew test` run stopped being
+  usable for verification: three attempts each failed for reasons unconnected
+  to any stub code (stale-daemon OOM, then two runs that stalled/timed out
+  with no `psi/stub` frames in any collected stack trace). Fell back to the
+  checkpoint-tier subset for those two commits instead — see the
+  `full-test-suite-instability-2026-07` memory entry for the full
+  investigation.
+
+## Completion
+
+All 19 planned commits landed 2026-07-27. `STUB_VERSION` never needed a bump
+— every file turned out to be a pure transliteration, no shape changes. The
+whole `psi/stub` package (56 files) is now Kotlin.

--- a/org/llm/traces/kotlin-conversion-symbol-walks-plan.md
+++ b/org/llm/traces/kotlin-conversion-symbol-walks-plan.md
@@ -1,0 +1,68 @@
+# Symbol-contribution walks: redesign + Kotlin conversion (roadmap item 2)
+
+## Context
+
+`RakuFileImpl.java` (622 lines) and `RakuPackageDeclImpl.java` (608 lines) are the load-bearing wall for completion, resolution, find-usages, and docs. The stub-vs-AST traversal duplication exists in **four** places, with behavioral drift between branches; the `sub EXPORT` path combines an async contribution to potentially-abandoned collectors with an `AtomicBoolean` CAS that silently skips work under contention. This is the "redesign once, deliberately" item from the roadmap.
+
+## Verified facts that drive the design
+
+1. **`isExported()` is AST-walking.** The `RakuPsiDeclaration` default calls `getTraits()` → `PsiTreeUtil` over children. The stub branches read `stub.isExported()` precisely to avoid forcing a parse of indexed dependency files. Therefore the redesign must NOT collapse to "map `stub.getPsi()` and dispatch on PSI interfaces" — cheap facts (scope, exported, name, packageKind, typeName) must come through a stub-or-AST lens, with PSI materialized only at contribution points (which is what both current branches already do).
+
+2. **Branch divergences in `contributeGlobals`** (RakuFileImpl:229-367):
+   - Enum gate: stub `isExported() || our` vs AST `our` only → unify to `isExported() || our`.
+   - `sub EXPORT` special-case exists only in the AST branch → after the EXPORT redesign, both lenses trigger it.
+   - Descent rules differ legitimately (stub tree contains only indexed decls; AST walk stops at `RakuPsiScope` boundaries) → keep per-lens structure rules.
+   - Package top-name: stub `getTypeName()` vs AST `getName()` → keep per-lens.
+
+3. **`contributeFromElders` is algorithm-split, not just accessor-split**: stub branch resolves trait names via `RakuLexicalTypeStubIndex`/`RakuGlobalTypeStubIndex`; AST branch via `PsiReference.resolve()`. Keep the two resolution strategies behind a `resolvedParents()` seam; write the contribution *ordering* (local parents → external parents → Cursor/Any/Mu chain, with `does()`/`is()` and `decreasePriority()`) once.
+
+4. **EXPORT machinery** (RakuFileImpl:331-390): `EXPORT_CACHE` field + `isCalculatingExport` CAS + `executeOnPooledThread` handing symbols to a collector the walk already abandoned. `dropExportCache()` is called by `RakuRoutineDeclImpl.java:427` via downcast — keep the name.
+
+5. Test-fixture pattern for cross-module behavior: `RakuMultiModuleProjectDescriptor` + `testData/multi-module` + `copyFileToProject("...", "../lib/...")` (see `MultiModuleCompletion.testCrossModules`).
+
+## Design
+
+### Unified walk with a facts lens
+
+New Kotlin sealed abstraction (lives with the impls, `org.raku.comma.psi.impl`):
+
+```kotlin
+sealed interface WalkNode {
+    fun children(): List<WalkNode>          // stub: childrenStubs; AST: RakuPsiElement children with scope-boundary rule
+    val category: Category?                 // Variable / Package / Routine / Enum / Subset / Use / Need / Other
+    fun scope(): String                     // stub-first
+    fun exported(): Boolean                 // stub-first (never forces AST for stubbed nodes)
+    fun name(): String?
+    fun psi(): RakuPsiElement               // materialize only at contribution points
+}
+class StubWalkNode(...) : WalkNode
+class AstWalkNode(...) : WalkNode
+```
+
+`contributeGlobals`, `contributeInternals`, `contributeNestedPackagesWithPrefix` each become ONE BFS written against `WalkNode`. `contributeFromElders` keeps its two parent-resolution strategies behind a seam but single contribution ordering.
+
+### EXPORT: explicit single-flight future
+
+Replace cache+CAS+fire-and-forget with one `AtomicReference<CompletableFuture<List<RakuSymbol>>>`:
+- future completed → contribute synchronously to the live collector;
+- absent → single-flight create + schedule on pooled thread; on completion call `RakuSdkUtil.triggerCodeAnalysis(project)` so abandoned resolutions re-run (this is the piece that fixes "cold cache = symbols never appear until something else invalidates");
+- pending → contribute nothing (same observable as today's cold path, minus the silent CAS skip).
+- `dropExportCache()` clears the reference (keeps the Java caller working).
+- After redesign, the EXPORT trigger fires from both lenses, not just AST.
+
+## Commit plan
+
+- **Commit 0 — characterization tests.** New `SymbolContributionWalkTest` using the multi-module fixture: our-sub/our-class transitive via `use`; `need` contribution; nested-package prefix (`Module::Inner::Deep`); exported-but-not-our enum from a stubbed dependency (pins the gate we're unifying to); a `sub EXPORT` module fixture pinning that nothing crashes and nothing contributes synchronously cold (strengthened in Commit C).
+- **Commit A — `RakuPackageDeclImpl` → Kotlin** with unified `contributeInternals` + `contributeNestedPackagesWithPrefix` (single BFS over WalkNode) and `contributeFromElders` behind the parents seam. Same FQN; `PsiMetaOwner` and stub-index usage unchanged.
+- **Commit B — `RakuFileImpl` → Kotlin** with unified `contributeGlobals` (single BFS), enum gate unified to `isExported() || our`, EXPORT semantics preserved verbatim (still AST-lens-only, still cache+CAS) to keep the commit mechanical-equivalent.
+- **Commit C — EXPORT redesign** as above + tests that resolution works once the future completes, and that the trigger fires from the stub lens too.
+
+Verification per commit: `MethodCompletionTest` (139 tests), `GoToDeclarationTest`, `FindUsageTest`, `DocumentationTest`, `MultiModuleCompletion`, the new walk tests, then full suite at the end. Green bar = no failures beyond the 6 known pre-existing + roaming leak flake. `eval "$(~/.rakubrew/bin/rakubrew init Zsh)"` before every gradle run.
+
+## Must not change
+
+- FQNs `org.raku.comma.psi.impl.RakuFileImpl` / `RakuPackageDeclImpl` (downcasts exist, e.g. `RakuRoutineDeclImpl.java:427`).
+- `STUB_VERSION` stays 29 (no stub serialization changes in this item).
+- Collector interface + both implementations (their asymmetric `isSatisfied` semantics are consumed everywhere; redesigning collectors is out of scope here).
+- `MOPSymbolsAllowed.does()/is()` semantics; the Cursor/Any/Mu implicit chain ordering; `decreasePriority()` call points.
+- `dependencyFile` early-return in `contributeGlobals` (known wart, but load-bearing; do not remove in this item).

--- a/org/llm/traces/parser-generated-lexer-architecture.md
+++ b/org/llm/traces/parser-generated-lexer-architecture.md
@@ -1,0 +1,128 @@
+# The generated lexer/parser: architecture, and how to change it safely
+
+**Read this before touching anything under `src/main/java/org/raku/comma/parsing/`.**
+The most important fact in this whole directory: `MAINBraid.java` is **generated
+code**, and the generator's source is **not in this repo**. Edit it wrong and you
+either corrupt a 54,000-line file by hand or silently lose your fix on the next
+regeneration. This doc exists so the next agent doesn't learn that the hard way.
+
+## What is generated, and from what
+
+- **`MAINBraid.java`** (~54K lines) — the Raku lexer state machine. `MAINBraid
+  extends Cursor<MAINBraid>`. Generated.
+- **`Cursor.java`**, **`CursorStack.java`** — hand-written runtime support for the
+  generated machine (backtracking, dynamic variables, the lookahead trampoline).
+  These are real source you can edit normally.
+- **`RakuLexer.java`** — the `LexerBase` adapter IntelliJ actually calls; drives
+  `MAINBraid` via a trampoline (`advance()`, lines ~82-115). Real source.
+
+The generator is **`p6-grammar-to-idea`**, a Raku program that transpiles a
+restricted-Raku-grammar DSL into these Java files. Its input is a ~162 KB grammar
+file `perl6.pm6`. As of this writing that tool lived at (an ephemeral, machine-local
+checkout):
+
+```
+/tmp/intellij-ide-plugin/perl6-idea-plugin/tools/p6-grammar-to-idea/
+    perl6.pm6                      # the grammar source of truth
+    lib/P6GrammarToIdea/*.pm6      # GenerateLexer.pm6, GenerateParser.pm6, etc.
+    README.md
+```
+
+That path is **not** guaranteed to exist. The upstream is the `perl6-idea-plugin`
+project (the original Comma plugin this is forked from). If you need to regenerate,
+locate that tooling first; do not assume `/tmp` still has it.
+
+`git log -- MAINBraid.java` shows only cosmetic/rename commits historically — it has
+never been regenerated in this repo. Treat it as vendored.
+
+## The mirror-fix discipline (do not skip)
+
+Because the grammar source is external and `MAINBraid.java` is what actually ships,
+a fix has to live in **both** places:
+
+1. **Patch `MAINBraid.java` directly** — surgically, minimal diff, with a comment
+   explaining what and why (it's generated, so the comment is the only signal to a
+   future reader that this line is intentional and not machine output).
+2. **Mirror the same change into `perl6.pm6`** in the external tooling, so a future
+   regeneration preserves it.
+
+Both fixes recorded in `parser-reduce-metaop-mislexing.md` were applied this way.
+If the external tooling is unavailable when you fix something, say so loudly in the
+commit message so the grammar-side change can be reconciled later.
+
+## Runtime model (enough to debug it)
+
+The lexer is a backtracking PEG-ish machine, flattened into integer-state switches.
+
+- Each grammar rule becomes a `_NNN_rulename()` method containing
+  `while (true) { switch (this.state) { case 0: ...; case 1: ...; } }`. State is an
+  `int`; each `case` advances `this.state` and either `continue`s, `return`s an
+  outcome code, or calls a sub-rule.
+- **Outcome codes** returned to the driving trampoline: `-1` = rule succeeded (pop
+  frame), `-2` = rule failed (pop frame), `-3` = emitted one token (yield), any other
+  value = "push this rule number as a new sub-frame".
+- **`Cursor` / `CursorStack`**: the rule-call stack is a stack of `Cursor` frames.
+  `RakuLexer.advance()` drives the top frame via `stack.peek().runRule()`.
+- **Backtracking** (`Cursor.java`): `bsMark(state)` / `bsFailMark(state)` push marks
+  onto a per-frame `backtrackStack` (4 ints per mark: state, pos, rep, flag);
+  `backtrack()` restores `state`+`pos` to the nearest real mark (fail-marks, pos<0,
+  are boundaries that just get popped). **`backtrack()` does NOT restore dynamic
+  variables** — only state and pos. Remember that when reasoning about side effects.
+- **Dynamic variables** (`$*IN_META`, `$*IN_REDUCE`, `$*PRECLIM`, `$*GOAL`, ...):
+  stored in a per-frame `Map<String,Object>` (`Cursor.dynamicVariables`).
+  `declareDynamicVariable` sets it on the current frame; `findDynamicVariable` walks
+  the frame stack top-down for the first frame that has it; `assignDynamicVariable`
+  walks down and mutates the frame that declared it. Dynamic scope = frame lifetime.
+  Truthiness (`isValueTruthy`): empty string and integer 0 are **falsy**; any
+  non-empty string and non-zero int are truthy. This matters — `$*IN_META` defaults
+  to `""` (falsy) and is set to `"red"`/`"X"`/... (truthy) inside meta contexts.
+
+## How to debug it (the methodology that worked)
+
+Pure static reading of a 54K-line generated file is slow and error-prone. Instrument
+instead. This is exactly how the reduce-metaop bug was cracked:
+
+1. **Token-stream dump.** `RakuLexer` is a standalone `LexerBase` — you can drive it
+   from a plain `junit.framework.TestCase` with no IDE fixture:
+   ```kotlin
+   val lexer = RakuLexer(); lexer.start(text, 0, text.length, 0)
+   while (lexer.tokenType != null) { /* print tokenStart/End/type/text */; lexer.advance() }
+   ```
+   Compare the token stream of a working input vs a broken one side by side. A
+   catastrophic mis-lex shows up as a giant `BAD_CHARACTER` token swallowing the rest
+   of the input.
+
+2. **Targeted `System.err` tracing inside a rule.** Add a `public static boolean
+   RD_DEBUG` flag to `MAINBraid` and print `state`/`pos`/relevant dyn-vars at the top
+   of the suspect `_NNN_rule()`. Toggle it from the test via `MAINBraid.RD_DEBUG =
+   true` and capture `System.err`. This tells you which state the machine gets stuck
+   in and whether a lookahead/args sub-rule fails. **Remove the instrumentation before
+   committing** (the two fixes' final diffs are guard-only, no debug left behind).
+
+3. **Canary-based swallow detection** (statement-boundary lens, PSI level): append a
+   distinctive trailing statement (`999999;`) after the suspect construct and check
+   whether it gets its own tiny `RakuStatement` node at the exact offset, or gets
+   swallowed into a larger containing statement. Clean, binary signal for "does this
+   construct eat what follows." Used to minimize both bugs to their smallest trigger.
+
+4. **Confirm a fix doesn't regress adjacent forms.** Temporarily revert just the guard
+   (a `/*TEMP-REVERT*/` one-liner) and re-run the minimization to prove the bug is
+   pre-existing / that your change is the thing that fixes it and nothing else.
+
+## Verifying parser changes
+
+- The parser-sensitive suites that do **not** route through the broken
+  `checkHighlighting` pipeline (see `test-harness-and-environment.md`) are the real
+  signal: `org.raku.comma.parsing.*`, `org.raku.comma.cro.parsing.*`,
+  `org.raku.comma.folding.*`, `org.raku.comma.formatter.*`.
+- House-style parser regression tests: `class FooTest : RakuParsingTestCase("dir")`
+  with `testData/parsing/dir/ParsingTestData.p6` (input) + `.txt` (golden PSI tree).
+  `doTest(true)` generates the `.txt` on first run (the run "fails" writing it), then
+  it passes. A clean golden tree has **no `PsiErrorElement` / `BAD_CHARACTER` nodes** —
+  that absence is itself the regression assertion. See
+  `testData/parsing/reduce-metaop-bug/` for a worked example.
+
+## See also
+
+- `parser-reduce-metaop-mislexing.md` — two real worked fixes to this machine.
+- `test-harness-and-environment.md` — how to run tests here at all.

--- a/org/llm/traces/parser-reduce-metaop-mislexing.md
+++ b/org/llm/traces/parser-reduce-metaop-mislexing.md
@@ -1,0 +1,96 @@
+# Reduce-metaop mis-lexing that collapsed highlighting mid-file
+
+**Fix:** merged to `main` via PR #47 ("2026.2 beta.3"); originally committed on
+branch `2026.2-beta.3` as `4aade331`. Regression test:
+`testData/parsing/reduce-metaop-bug/` + `ReduceMetaopBugTest`.
+
+**Prerequisite reading:** `parser-generated-lexer-architecture.md` (this is a fix to
+that generated machine; the mirror-fix discipline and debug methodology come from
+there).
+
+## Symptom
+
+A user reported syntax highlighting "stops completely at line 307" of a ~930-line
+`Math::Matrix.rakumod`. Everything after that point rendered as one undifferentiated
+blob. It was not a crash — it was a single mis-parsed statement swallowing the rest
+of the file, which then made an unrelated inspection (`UselessUseInspection`, "useless
+use in sink context") appear to highlight the entire tail of the file.
+
+The trigger on line 307 was a reduce meta-operator applied to a `map` whose block
+contained a nested `map`:
+```raku
+my Bool $rowwise = [and] map { &$greater(@!rows[$^r][$^r] * 2,
+                              [+](map {abs $^c}, @!rows[$^r].flat)) }, ^$!row-count;
+```
+
+## Two distinct root causes (both: "the metaop machinery accepted something it
+shouldn't", so `[...]` fell through to the array-composer branch and left trailing
+tokens orphaned as `BAD_CHARACTER`)
+
+### Bug 1 — wordy reduce operators (`[and]`, `[or]`, `[xor]`) not recognized
+
+`term_reduce`'s lookahead (`perl6.pm6`) is `<?before ['[' [infixish('red')] ']']>`.
+It calls `infixish` → `token infix`, which ends with a precedence guard:
+```
+<!{ $*PREC le $*PRECLIM }>          # perl6.pm6 line ~4260
+```
+That guard is an **expression-precedence-climbing** concern. But when we're merely
+*identifying the base operator of a meta-operator*, `$*PRECLIM` still holds the
+enclosing assignment-RHS limit — so loose-precedence operators get filtered out.
+Symbolic ops slipped through (`[+]` is `t=`, `[*]` is `u=`); wordy ones did not
+(`and` is `d=`, `or` is `c=`). Confirmed empirically by tracing `term_reduce`: for
+`[+]`/`[*]` it reached its final state; for `[and]` it never left state 0 (the
+lookahead failed).
+
+**Fix:** only apply the precedence guard in ordinary infix position (`$*IN_META`
+empty). Generated code `MAINBraid.java` `_225_infix()` case 177:
+```java
+if (!this.isValueTruthy(this.findDynamicVariable("$*IN_META"))
+        && this.isValueTruthy(this.testStrLE(findDynamicVariable("$*PREC"),
+                                              findDynamicVariable("$*PRECLIM")))) { ... }
+```
+Grammar mirror `perl6.pm6`: `[ <?{ $*IN_META }> || <!{ $*PREC le $*PRECLIM }> ]`.
+
+### Bug 2 — `[[]]` (empty inner array) mis-parsed as a reduce metaop
+
+`[[]]` was lexed as a reduce metaop `[ [] ]`: the reduce lookahead accepted `[[]`
+because `infixish` matched an **empty / incomplete bracketed infix** (a `[` with no
+operator inside) via the editor-tolerance fallback in `infixish_non_assignment_meta`.
+That consumed the *inner* `]` as the reduce's closing bracket and orphaned the *outer*
+`]` → `BAD_CHARACTER` cascade to EOF. Minimization proved `xx` was a red herring:
+`[[]]` alone breaks; `[[1] xx 3]` (non-empty inner) is fine; `([] xx 3)` (parens) is
+fine. The trigger is specifically `[[` — an array composer whose first element is an
+empty array.
+
+**Fix:** a meta-operator's base must be a *complete* operator, so the incomplete
+bracketed-infix fallback must not fire in a meta context. `MAINBraid.java`
+`_223_infixish_non_assignment_meta()` case 14 (the standalone incomplete fallback):
+guard it with `if (isValueTruthy(findDynamicVariable("$*IN_META"))) { backtrack... }`
+so it fails in meta context, letting `[[]]` fall through to nested array composers.
+Grammar mirror `perl6.pm6` line ~4063: prefix the fallback alternative with
+`<!{ $*IN_META }>`.
+
+## The transferable principle
+
+> **A meta-operator (`[op]` reduce, `Xop` cross, `Zop` zip, `>>op<<` hyper, `Rop`,
+> `Sop`, negated) wraps a *complete* base operator, and does so regardless of the
+> surrounding expression's precedence limit.**
+
+Both fixes are the same idea from two angles: guard-on-`$*IN_META`. Any future
+"metaop X isn't recognized" or "metaop Y swallows the file" bug should first be
+checked against this principle — is some ordinary-infix-position constraint
+(precedence, completeness, a stopper) leaking into meta-operator identification?
+
+## Why it looked intermittent / "sometimes worked"
+
+Symbolic reduces always worked, wordy ones never did, and the file-swallow only
+became visually catastrophic when a nested brace (`map {...}` inside `map {...}`)
+made error-recovery mis-count and swallow to EOF instead of recovering at the next
+`}`. Same mis-lex underneath; different blast radius. Don't be misled by "it works
+sometimes" — reduce it to the minimal trigger (canary method).
+
+## Regression coverage
+
+`testData/parsing/reduce-metaop-bug/ParsingTestData.p6` exercises wordy/symbolic/
+nested/bracketed reduces and empty-array composers; its golden `.txt` has no error or
+`BAD_CHARACTER` nodes. That absence is the assertion.

--- a/org/llm/traces/stub-building-index-queries.md
+++ b/org/llm/traces/stub-building-index-queries.md
@@ -1,0 +1,56 @@
+# Stub building must not query the stub index (a whole class of latent bug)
+
+**Fix (partial, by design):** merged to `main` via PR #47; originally `c560d9b4` on
+`2026.2-beta.3`.
+
+## The platform rule
+
+IntelliJ forbids stub building from depending on index data. When
+`StubElementType.createStub()` (or anything it transitively calls) queries a stub
+index, the platform logs `Stub building must not rely on data from indexes ...`
+(`FileBasedIndexImpl.ensureUpToDate` → `Logger.error`). Building the stub for file X
+must not depend on the very index it is helping populate.
+
+- **In production:** this degrades **silently** — the offending resolution returns an
+  empty/wrong result and building continues. No crash, no visible error. Symptoms are
+  subtle (wrong/missing symbols until a reindex), which is why these bugs lurk.
+- **Under the test harness:** `-Dintellij.testFramework.rethrow.logged.errors=true`
+  (set for all test JVMs here) escalates that `Logger.error` to a hard
+  `TestLoggerAssertionError`. So a test can "crash" on something that a real IDE just
+  shrugs off. Keep that asymmetry in mind — see `test-harness-and-environment.md`.
+
+## The specific instance fixed
+
+`RakuVariableDeclStubElementType.createStub()` called `psi.inferType()`. For `@`/`%`
+-sigil variables with an `is` trait (`has @!foo is SomeCustomArrayClass;`),
+`inferType()` resolves the trait via `RakuIsTraitReference.resolve()` — a cross-file,
+index-backed lookup — illegal during stub building.
+
+**Fix:** added `RakuVariableDeclImpl.inferTypeForStub()`, identical to `inferType()`
+except it skips the `is`-trait-as-base-type resolution, and `createStub()` calls it.
+Real callers still get the fully-resolved type from `inferType()` once the PSI is
+materialized. (This was the deliberately **narrow** "Option A" — fix the one illegal
+path, not a broad "detect stub-building context inside resolve()".)
+
+## Still open / known-incomplete
+
+Verification during the fix surfaced a **second** index-query path via
+`RakuTypeNameImpl.inferType()` → `RakuTypeNameReference.resolve()` (resolving explicit
+type annotations like `Int`/`Bool`), which is far more pervasive — it triggers for
+nearly any explicitly-typed declaration. It was **not** fixed, for two reasons:
+1. The narrow Option A was the chosen scope.
+2. This class of bug degrades silently in production (see above), so it is not the
+   cause of any visible user-facing breakage — it is latent correctness debt, not a
+   live fire.
+
+If you pick this up: the general options are (a) keep whittling individual illegal
+paths stub-safe (like Option A), or (b) a broader "am I inside stub building?" guard
+that resolve() can consult. (b) is more invasive and needs care not to change
+resolution semantics for real callers. Prefer (a) unless the paths multiply.
+
+## How to detect it
+
+Any new symptom that only fails under the test harness with the "Stub building must
+not rely on data from indexes" message is this class of bug. In a scratch test you
+can scope-suppress *only that message* via `LoggedErrorProcessor` to see what else is
+going on underneath, but the real fix is to make the `createStub` path index-free.

--- a/org/llm/traces/test-harness-and-environment.md
+++ b/org/llm/traces/test-harness-and-environment.md
@@ -1,0 +1,87 @@
+# Running and testing this plugin: environment gotchas
+
+Practical, load-bearing knowledge for getting tests to run and trusting their
+results. Several of these will waste an hour if you don't know them up front.
+
+## rakubrew must be initialized in the same shell as gradle
+
+Tests spawn a real `raku` subprocess to load symbols. If `raku` isn't on `PATH`, they
+fail in `setUp()` (`CommaFixtureTestCase.suggestSdkHome()` → "Found a raku in path"
+assertion, or a symbol-load timeout). Every gradle invocation must be preceded, **in
+the same shell**, by:
+
+```bash
+eval "$(~/.rakubrew/bin/rakubrew init Zsh)"
+./gradlew test --tests "..."
+```
+
+Shell state does not persist between tool calls, so put both in one command.
+
+## The `checkHighlighting()` / `doHighlighting()` pipeline is broken in this environment
+
+Since an SDK bump, the highlighting pipeline fails even for otherwise-untouched tests
+here (annotation/highlighting suites time out or error). This is environmental, not
+your change. Consequences:
+
+- **Do not** trust a red result from `org.raku.comma.annotation.*` /
+  `org.raku.comma.highlighting.*` as evidence your change broke something — it may be
+  the pre-existing pipeline breakage, indistinguishable from a real failure.
+- **Write inspection/parser regression tests that bypass it.** For inspections, invoke
+  `provideVisitFunction` directly over the PSI and assert on `ProblemsHolder.results`
+  (see `MissingRoleMethodInspectionTest`). For parsing, use the golden-PSI-tree
+  `RakuParsingTestCase` framework (see `parser-generated-lexer-architecture.md`).
+- Reliable parser/structure suites that don't route through it:
+  `org.raku.comma.parsing.*`, `org.raku.comma.cro.parsing.*`, `org.raku.comma.folding.*`,
+  `org.raku.comma.formatter.*`, `org.raku.comma.stub.*`.
+
+## Logged errors are escalated to hard failures under test
+
+All test JVMs run with `-Dintellij.testFramework.rethrow.logged.errors=true`. Any
+`Logger.error(...)` becomes a `TestLoggerAssertionError`. So things a real IDE only
+logs-and-continues (a background coroutine failing, a stub-index-during-stub-building
+warning) become test failures. Two real examples handled this way:
+
+- **CodeVision** (`c7beea6b`): the bundled Kotlin plugin's
+  `KotlinScriptDefinitionCodeVisionProvider` fails a resource-bundle lookup in this
+  sandbox and logs an error from a background coroutine during project startup. In
+  real use it's harmless. `CommaFixtureTestCase.runBare()` scope-suppresses **only
+  that one message** via `LoggedErrorProcessor` so genuine logged-error regressions
+  still fail loudly. `runBare()` (not `runTestRunnable()`) is required because the
+  coroutine can fire during `setUp()`, before the test body.
+- **Stub-index-during-stub-building** — see `stub-building-index-queries.md`.
+
+Pattern for suppressing exactly one known-benign message in a scratch test:
+```kotlin
+LoggedErrorProcessor.executeWith<Throwable>(object : LoggedErrorProcessor() {
+    override fun processError(category, message, details, t) =
+        if (message.contains("<known-benign-substring>")) Action.NONE
+        else super.processError(category, message, details, t)
+}) { /* body */ }
+```
+
+## Full-suite instability; use a checkpoint subset
+
+The full `./gradlew test` has hung/timed out repeatedly in this environment. A curated
+subset (stub + parsing + a few completion/cro suites) is the reliable signal after a
+change. Run the suites relevant to what you touched, plus the parser/structure suites
+above, rather than betting on a clean full run.
+
+## Scratch tests: write outputs to a randomized temp dir
+
+Investigation/scratch tests should write to a fresh randomized directory under the
+user temp dir (JVM `java.io.tmpdir`, the equivalent of Raku's `$*TMPDIR`), not a fixed
+path, so repeated/concurrent runs don't clobber each other and echo the path so it's
+discoverable:
+```kotlin
+val dir = Files.createTempDirectory("raku-scratch-<label>-").toFile()
+File(dir, "out.txt").writeText(...); println("[scratch] wrote ${'$'}dir/out.txt")
+```
+
+## Running the sandbox IDE
+
+`./gradlew runIde` launches a sandbox IDE with the plugin. Used to reproduce
+user-facing symptoms (e.g. highlighting) that the broken test-highlighting pipeline
+can't. `.rakumod` module-file support depends on `<depends>com.intellij.modules.platform</depends>`
+/ JCEF wiring in `plugin.xml` (a tab that opens and immediately closes is that
+dependency missing — cf. commit `c2c45083` "Fix .rakumod loading by explicitly
+depending on JCEF").


### PR DESCRIPTION
Agent-authored investigation traces and planning docs, committed to the repo so they travel across machines (per-machine ~/.claude memory does not). Consolidates the loose root-level planning docs and adds new traces for recent work:

- README: orientation + reading order + conventions
- parser-generated-lexer-architecture: MAINBraid.java is generated from an external grammar (perl6.pm6); runtime model; debug methodology; mirror-fix discipline. Read before touching parsing/.
- parser-reduce-metaop-mislexing: the [and]/[[]] reduce-metaop fixes (PR #47)
- inspection-private-role-methods: private role methods aren't Raku requirements (PR #47)
- stub-building-index-queries: index-query-during-stub-building bug class (PR #47)
- test-harness-and-environment: rakubrew, broken checkHighlighting, logged-error escalation, checkpoint subset
- relocated: kotlin-conversion-* plans/journey, bumping-supported-idea-version